### PR TITLE
preliminary test to see if store view names are displayed on the lang…

### DIFF
--- a/ViewModel/StoreSwitchModel.php
+++ b/ViewModel/StoreSwitchModel.php
@@ -183,18 +183,18 @@ class StoreSwitchModel implements ArgumentInterface
 
     /**
      * Get the formatted label for the dropdown, based on the format configuration.
-     * 
+     *
      * @param StoreInterface $store
      *
      * @return string
      * @throws \Exception
      */
-    public function getStoreSwitchLabel(StoreInterface $store): string 
+    public function getStoreSwitchLabel(StoreInterface $store): string
     {
         $showCountryOnly = $this->scopeConfig->getValue(self::MODULE_SHOW_COUNTRY_ONLY_CONFIG_PATH, ScopeInterface::SCOPE_STORE, $store->getId());
         if($showCountryOnly) {
             return $this->getStoreCountyCode($store);
         }
-        return $this->getParsedLanguage($store).'&nbsp;('.$this->getStoreCountyCode($store).')';
+        return $this->storeManager->getStore($store)->getName($store);
     }
 }


### PR DESCRIPTION
I've edited <b>ViewModel/StoreSwitchModel.php</b> file to test if I could get store view names displayed on the language switcher rather than the language/country code.

I changed the code within an existing function: <code><b>line 192:</b>    public function getStoreSwitchLabel(StoreInterface $store): string</code>

(by editing this function, it means the loss of the ability to view the Country Name with Country Character Code together on the language switcher. However, this is just a preliminary trial.  I intend on making a separate PHP function to display Store View Names, so all existing functions will be restored)

I've tested this on Magento 2.3.5 and the 'store view names' are all displaying correctly on the language switcher.

I am new to Magento development and unsure whether the code that I used is the best way to achieve displaying all the store names. 

It now requires a separate PHP function within <b>ViewModel/StoreSwitchModel.php</b> and an option within the Magento admin dashboard to allow a user to choose and display "Store View Names".

I will try and edit the following files to achieve this:

ViewModel/StoreSwitchModel.php
etc/adminhtml/system.xml
etc/config.xml
view/frontend/templates/switch/languages.phtml